### PR TITLE
fix(snyk): fork badges branch from main

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -71,15 +71,10 @@ jobs:
           CONTENT=$(base64 -w0 /tmp/snyk-badge.json)
 
           if ! gh api repos/tang-edge/tang-edge/branches/badges -q '.name' >/dev/null 2>&1; then
-            BASE_SHA=$(gh api repos/tang-edge/tang-edge/git/refs/heads/main -q '.object.sha')
-            EMPTY_TREE=$(gh api repos/tang-edge/tang-edge/git/trees --method POST -q '.sha')
-            INITIAL=$(gh api repos/tang-edge/tang-edge/git/commits \
-              -f message="init badges branch" \
-              -f tree="$EMPTY_TREE" \
-              -q '.sha')
+            MAIN_SHA=$(gh api repos/tang-edge/tang-edge/git/refs/heads/main -q '.object.sha')
             gh api repos/tang-edge/tang-edge/git/refs \
               -f ref="refs/heads/badges" \
-              -f sha="$INITIAL"
+              -f sha="$MAIN_SHA"
           fi
 
           FILE_SHA=$(gh api "repos/tang-edge/tang-edge/contents/snyk-badge.json?ref=badges" -q '.sha' 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Create `badges` branch from main SHA instead of empty tree (Git Data API rejects empty trees)
- First run forks from main, subsequent runs update file via Contents API