### PR TITLE
fix(snyk): rename branch to snyk-badge to avoid conflict

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -71,11 +71,11 @@ jobs:
           cd /tmp
           git init badges-repo
           cd badges-repo
-          git checkout --orphan badges
+          git checkout --orphan snyk-badge
           cp /tmp/snyk-badge.json snyk-badge.json
           git add snyk-badge.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "update snyk badge"
           git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/tang-edge/tang-edge.git"
-          git push -f origin badges
+          git push -f origin snyk-badge

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=tang-edge-org_tang-edge&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=tang-edge-org_tang-edge)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=tang-edge-org_tang-edge&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=tang-edge-org_tang-edge)
 [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=tang-edge-org_tang-edge&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=tang-edge-org_tang-edge)
-[![Snyk](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tang-edge/tang-edge/badges/snyk-badge.json)](https://app.snyk.io/org/tang-edge-worker/projects)
+[![Snyk](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tang-edge/tang-edge/snyk-badge/snyk-badge.json)](https://app.snyk.io/org/tang-edge-worker/projects)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tang-edge/tang-edge/badge)](https://scorecard.dev/viewer/?uri=github.com/tang-edge/tang-edge)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12036/badge?level=silver)](https://www.bestpractices.dev/projects/12036)
 [![Platforms](https://img.shields.io/badge/platforms-9-brightgreen)](https://github.com/tang-edge/tang-edge?tab=readme-ov-file#supported-platforms)


### PR DESCRIPTION
## Summary
- Root cause: branch name `badges` conflicted with existing ref `badges/codeql` (GitHub directory-file namespace collision)
- Renamed to `snyk-badge` which doesn't conflict with any existing ref
- Updated README badge URL accordingly