### PR TITLE
fix(docker): update Fastly CLI and Deno to fix 404 download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 FROM oven/bun:1@sha256:856da45d07aeb62eb38ea3e7f9e1794c0143a4ff63efb00e6c4491b627e2a521
 
 ARG TARGETARCH
-ARG DENO_VERSION=v2.7.1
-ARG FASTLY_VERSION=v14.0.1
+ARG DENO_VERSION=v2.7.12
+ARG FASTLY_VERSION=v14.3.1
 
 # System deps (ca-certificates required for curl HTTPS downloads)
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Fastly CLI `v14.0.1` download URL returns 404 — bump to `v14.3.1`
- Deno `v2.7.1` → `v2.7.12` (latest)
- Fixes Docker push failure in release workflow