### PR TITLE
fix(docker): add artifact-metadata write permission

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
       id-token: write
       attestations: write
       security-events: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
Add  permission to fix storage record warnings in Docker workflow.