### PR TITLE
fix(snyk): pin snyk/actions/node to SHA (Scorecard #431, #432)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun install
 
       - name: Run Snyk monitor
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Snyk test
         id: snyk_test
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- Replaces floating `snyk/actions/node@master` ref with pinned SHA `9adf32b` (`v1.0.0` tag) in two steps of the Snyk workflow.
- Resolves Scorecard `Pinned-Dependencies` alerts [#431](https://github.com/tang-edge/tang-edge/security/code-scanning/431) and [#432](https://github.com/tang-edge/tang-edge/security/code-scanning/432).
- `v1.0.0` is the latest tag and matches `master` HEAD modulo a single non-functional codeowners update — runtime behavior is unchanged.

## Test plan

- [ ] Snyk workflow runs successfully on next push to `main`
- [ ] Scorecard re-scan no longer flags `Pinned-Dependencies` for `snyk.yml`