### PR TITLE
fix(snyk): write test results into workspace, bump hono to 4.12.27

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -39,7 +39,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: test
-          args: --org=tang-edge-worker --project-name=tang-edge --json-file-output=/tmp/snyk-result.json
+          args: --org=tang-edge-worker --project-name=tang-edge --json-file-output=snyk-result.json
         continue-on-error: true
 
       - name: Generate badge data
@@ -47,8 +47,8 @@ jobs:
           if [ "${{ steps.snyk_test.outcome }}" = "success" ]; then
             COLOR="brightgreen"
             MESSAGE="0 vulnerabilities"
-          elif [ -f /tmp/snyk-result.json ]; then
-            COUNT=$(jq '.uniqueCount // 0' /tmp/snyk-result.json 2>/dev/null || echo "0")
+          elif [ -f snyk-result.json ]; then
+            COUNT=$(jq '.uniqueCount // 0' snyk-result.json 2>/dev/null || echo "0")
             if [ "$COUNT" = "0" ]; then
               COLOR="brightgreen"
               MESSAGE="0 vulnerabilities"

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "tang-edge",
       "dependencies": {
         "@noble/curves": "^2.0.1",
-        "hono": "^4.12.14",
+        "hono": "^4.12.27",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260303.0",
@@ -170,7 +170,7 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@noble/curves": "^2.0.1",
-    "hono": "^4.12.14"
+    "hono": "^4.12.27"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260303.0",


### PR DESCRIPTION
## Why the badge was yellow

The `snyk/actions/node` step runs in a Docker container that only mounts the workspace. `--json-file-output=/tmp/snyk-result.json` wrote inside the container, so the badge step on the runner never found the file and fell back to yellow "check results".

## Changes

- Write `snyk-result.json` into the workspace so the badge step can read the real vulnerability count.
- Bump `hono` 4.12.14 → 4.12.27 — clears all 14 known vulnerabilities Snyk was reporting (incl. High: Directory Traversal SNYK-JS-HONO-17356405, Permissive Cross-domain Policy SNYK-JS-HONO-17356430, Resource Allocation Without Limits SNYK-JS-HONO-16438966), so the badge goes green rather than red.

Tests: 200/200 pass locally.